### PR TITLE
ProcedureGen.unity > Health bar & Treasure box anchor upper right

### DIFF
--- a/Assets/Game/Graphics/Animations/_Devil/char_Devil.controller
+++ b/Assets/Game/Graphics/Animations/_Devil/char_Devil.controller
@@ -324,8 +324,8 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0.25
   m_TransitionOffset: 0
-  m_ExitTime: 0.5
-  m_HasExitTime: 1
+  m_ExitTime: 0
+  m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1

--- a/Assets/Game/Graphics/Sprites/Characters/Enemy/_.meta
+++ b/Assets/Game/Graphics/Sprites/Characters/Enemy/_.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1672a487ed54dea40866c7d353b042eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Game/Prefabs/Maps/RoadBlock.prefab
+++ b/Assets/Game/Prefabs/Maps/RoadBlock.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 8507085920621568338}
   - component: {fileID: -1705342393274425506}
+  - component: {fileID: 7776273816663713120}
+  - component: {fileID: -7160439001701357366}
   m_Layer: 2
   m_Name: RoadBlock
   m_TagString: Untagged
@@ -25,7 +27,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4134873573646573511}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -84.04022, y: 0.19788656, z: 15.894425}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -38,7 +40,7 @@ NavMeshObstacle:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4134873573646573511}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 3
   m_Shape: 1
   m_Extents: {x: 0.25, y: 10, z: 1.25}
@@ -47,3 +49,28 @@ NavMeshObstacle:
   m_CarveOnlyStationary: 1
   m_Center: {x: 0, y: 0, z: 0}
   m_TimeToStationary: 0.5
+--- !u!114 &7776273816663713120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4134873573646573511}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d5aaa88317d313247ab5cc4a92de2735, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!65 &-7160439001701357366
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4134873573646573511}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.5, y: 20, z: 2.5}
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/Game/Scenes/newgame/ProcedureGen.unity
+++ b/Assets/Game/Scenes/newgame/ProcedureGen.unity
@@ -294,6 +294,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5194179591698239641, guid: 305c261817b7240479249b29b3e13da6,
         type: 3}
+      propertyPath: _roadBlockCol
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5194179591698239641, guid: 305c261817b7240479249b29b3e13da6,
+        type: 3}
       propertyPath: _nextMapColliderCol
       value: 8
       objectReference: {fileID: 0}
@@ -515,33 +520,23 @@ MonoBehaviour:
   - prefab: {fileID: 5921409440072016248, guid: 9d33d969a2dafe042a1bf0fc0c8a35fe,
       type: 3}
     cooldown: 5
-    maxNumber: 21
     enabled: 1
-    spawnedCountDoNotTouch: 0
   - prefab: {fileID: 5921409440072016248, guid: f0f7b51b50ce547dfb3e84bc0451acd5,
       type: 3}
     cooldown: 5
-    maxNumber: 20
     enabled: 0
-    spawnedCountDoNotTouch: 0
   - prefab: {fileID: 7155914395970087737, guid: 855c9ad4221d6c54cb36b3873f6271a8,
       type: 3}
     cooldown: 5
-    maxNumber: 44
     enabled: 0
-    spawnedCountDoNotTouch: 0
   - prefab: {fileID: 2751151623452151826, guid: 45b903535c5d4594fb65d04fa73c4f35,
       type: 3}
     cooldown: 5
-    maxNumber: 42
     enabled: 0
-    spawnedCountDoNotTouch: 0
   - prefab: {fileID: 2751151623452151826, guid: c26cb3d4d54158641888bfc9a52371d5,
       type: 3}
     cooldown: 5
-    maxNumber: 38
     enabled: 0
-    spawnedCountDoNotTouch: 0
   minSpawnDistanceFromPlayer: 20
   maxSpawnDistanceFromPlayer: 35
 --- !u!114 &411637829
@@ -987,7 +982,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1017198208 stripped
 RectTransform:
@@ -1048,6 +1043,11 @@ PrefabInstance:
         type: 3}
       propertyPath: pathRadius
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2213536328421049312, guid: f97bd1b7db627d94ebc0b6614f6f91d0,
+        type: 3}
+      propertyPath: _roadBlockCol
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2213536328421049313, guid: f97bd1b7db627d94ebc0b6614f6f91d0,
         type: 3}
@@ -1441,7 +1441,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1699230477
 GameObject:
@@ -1639,6 +1639,11 @@ PrefabInstance:
         type: 3}
       propertyPath: pathRadius
       value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1803612015275866308, guid: 30a2e599a91492e4a8bb6d233e75b2e4,
+        type: 3}
+      propertyPath: _roadBlockCol
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1803612015275866331, guid: 30a2e599a91492e4a8bb6d233e75b2e4,
         type: 3}
@@ -2028,18 +2033,53 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 6.816986
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 280
+      value: -103.14
       objectReference: {fileID: 0}
     - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 200
+      value: -105.8
       objectReference: {fileID: 0}
     - target: {fileID: 5393367580200256100, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}
       propertyPath: m_IsActive
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580434057247, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.10998535
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580434057247, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -0.020050049
       objectReference: {fileID: 0}
     - target: {fileID: 5393367581470950364, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}

--- a/Assets/Game/Scenes/newgame/ProcedureGen.unity
+++ b/Assets/Game/Scenes/newgame/ProcedureGen.unity
@@ -1264,7 +1264,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
+  m_MatchWidthOrHeight: 0.5
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -1348,7 +1348,7 @@ RectTransform:
   m_GameObject: {fileID: 1540719178}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1.2781, y: 1.2781, z: 1.2781}
   m_Children: []
   m_Father: {fileID: 1862789574}
   m_RootOrder: 0
@@ -1833,7 +1833,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -78.799805, y: -80}
+  m_AnchoredPosition: {x: -100.6, y: -73.7}
   m_SizeDelta: {x: 50.037476, y: 6.816986}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1862789575
@@ -2011,6 +2011,11 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4448470777677463001, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_MatchWidthOrHeight
+      value: 0.5
+      objectReference: {fileID: 0}
     - target: {fileID: 4452140354269660986, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}
       propertyPath: hideHealBarWhenFull
@@ -2025,6 +2030,26 @@ PrefabInstance:
         type: 3}
       propertyPath: healthBarFollowCharacter
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367579970597898, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5451
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367579970597898, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5451
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367579970597898, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5451
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367579970597898, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -46.64
       objectReference: {fileID: 0}
     - target: {fileID: 5393367579970597899, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}
@@ -2050,6 +2075,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 81.09
       objectReference: {fileID: 0}
     - target: {fileID: 5393367580200256099, guid: c5ce113d662375847963f9f42aedc089,
         type: 3}

--- a/Assets/Game/Scripts/Character/Health.cs
+++ b/Assets/Game/Scripts/Character/Health.cs
@@ -16,10 +16,11 @@ public class Health : ActorActionComponent
   private float _currentHealth;
   private bool _isDead;
 
-  private void Awake()
-  {
-    InvokeRepeating(nameof(RegenerateHealth), 0.0f, 1.0f);
-  }
+  // // This will regen health starting at awake, repeated every 1 sec
+  // private void Awake()
+  // {
+  //   InvokeRepeating(nameof(RegenerateHealth), 0.0f, 1.0f);
+  // }
 
   protected override void Start()
   {
@@ -32,8 +33,8 @@ public class Health : ActorActionComponent
 
   private void Update()
   {
-    if (healthBarFollowCharacter)
-      healthBar.transform.position = Camera.main.WorldToScreenPoint(GetActor().transform.position);
+    if (healthBarFollowCharacter) { healthBar.transform.position = Camera.main.WorldToScreenPoint(GetActor().transform.position); }
+    RegenerateHealth();
   }
 
   private void RegenerateHealth()
@@ -42,7 +43,7 @@ public class Health : ActorActionComponent
     {
       return;
     }
-    _currentHealth += GetActor().GetBaseStats().HealthRegenPerSecond;
+    _currentHealth += (GetActor().GetBaseStats().HealthRegenPerSecond * Time.deltaTime);
     _currentHealth = Math.Min(_currentHealth, GetActor().GetBaseStats().MaxHealth);
     UpdateHealthBar();
   }

--- a/Assets/Game/Scripts/GameManager.cs
+++ b/Assets/Game/Scripts/GameManager.cs
@@ -31,7 +31,6 @@ namespace Game.Scripts
             playAgainButton.onClick.AddListener(StartGame);
             Statistic.Reset(player);
         }
-        
 
         public int RewardAmountMax => rewardAmountMax;
 
@@ -46,7 +45,7 @@ namespace Game.Scripts
 
             for (int i = 0; i < cooldown.Length; i += 1)
             {
-                if (!spawnContents[i].enabled || spawnContents[i].spawnedCountDoNotTouch >= spawnContents[i].maxNumber)
+                if (!spawnContents[i].enabled /*|| spawnContents[i].spawnedCountDoNotTouch >= spawnContents[i].maxNumber*/ )
                     continue;
 
                 if (cooldown[i] == 0)
@@ -54,7 +53,7 @@ namespace Game.Scripts
                     GameObject gameObject = PoolManager.Spawn(spawnContents[i].prefab, Utils.GetRandomPoint(player.transform.position, minSpawnDistanceFromPlayer, maxSpawnDistanceFromPlayer));
                     gameObject.transform.LookAt(Utils.GetRandomPoint());
                     cooldown[i] = spawnContents[i].cooldown;
-                    spawnContents[i].spawnedCountDoNotTouch += 1;
+                    // spawnContents[i].spawnedCountDoNotTouch += 1;
                 }
                 else
                 {
@@ -100,7 +99,7 @@ namespace Game.Scripts
                 playTime += playTimeSpan.Minutes + "m ";
             playTime += playTimeSpan.Seconds + "s";
 
-            int xDistance = Convert.ToInt32((player.gameObject.transform.position.x - Statistic.StartPosition.x) /2);
+            int xDistance = Convert.ToInt32((player.gameObject.transform.position.x - Statistic.StartPosition.x) / 2);
             string gameResult = String.Format("{0}\n{1}m\n{2}", playTime, xDistance, Statistic.EnemyKilled);
             gameResultText.SetText(gameResult);
         }
@@ -111,9 +110,9 @@ namespace Game.Scripts
             public GameObject prefab;
             public int cooldown;
             [Range(1, 100)]
-            public int maxNumber = 1;
+            // public int maxNumber = 1;
             public bool enabled;
-            public int spawnedCountDoNotTouch = 0;
+            // public int spawnedCountDoNotTouch = 0;
         }
     }
 }

--- a/Assets/Game/Scripts/MapGeneration/MapManager.cs
+++ b/Assets/Game/Scripts/MapGeneration/MapManager.cs
@@ -73,16 +73,6 @@ public class MapManager : MonoBehaviour
         return _planeBuilder.GetSize();
     }
 
-    /*     public void DestroyPreviousMap()
-        {
-            PlaceRoadBlock();
-            if (mapNumber != 0)
-            {
-                Destroy(_previousMap.gameObject);
-            }
-        } */
-    
-
     public void PlaceRoadBlock()
     {
         if (!_roadBlockPlaced)
@@ -128,16 +118,23 @@ public class MapManager : MonoBehaviour
 
     private void PlaceColliders()
     {
-        /*     GameObject newDestroyCollider = Instantiate(
-                _destroyCollider,
-                new Vector3((-width / 2 + _destroyColliderCol) * unit + transform.position.x, 0, 0),
-                Quaternion.identity,
-                transform
-            ); */
+        GameObject newDestroyCollider = Instantiate(
+            _destroyCollider,
+            new Vector3((-width / 2 + _destroyColliderCol) * unit + transform.position.x, 0, 0),
+            Quaternion.identity,
+            transform
+        );
 
         GameObject newNextMapCollider = Instantiate(
             _nextMapCollider,
             new Vector3((-width / 2 + _nextMapColliderCol) * unit + transform.position.x, 0, 0),
+            Quaternion.identity,
+            transform
+        );
+
+        GameObject newRoadBlock = Instantiate(
+            _roadBlock,
+            new Vector3((-width / 2 + _roadBlockCol) * unit + transform.position.x, 0, (-height / 2 + mapGenerator.GetStartPoint().tileY) * unit + transform.position.z),
             Quaternion.identity,
             transform
         );

--- a/Assets/Game/Scripts/MapGeneration/MapTriggers/NextMapCollider.cs
+++ b/Assets/Game/Scripts/MapGeneration/MapTriggers/NextMapCollider.cs
@@ -31,6 +31,7 @@ public class NextMapCollider : MonoBehaviour
                     Statistic.IncrementCurrentLevel();
                     mapManager.shouldUpdateSprite = true;
                     mapManager.GenerateMap();
+                    mapManager.PlaceRoadBlock();
                     parentMapObject.transform.Find("WorldBoundary").position += new Vector3(25, 0, 0);
 
                     // position.x += 25f;

--- a/Assets/Game/Scripts/MapGeneration/MapTriggers/RoadBlockActivate.cs
+++ b/Assets/Game/Scripts/MapGeneration/MapTriggers/RoadBlockActivate.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.AI;
+
+public class RoadBlockActivate : MonoBehaviour
+{
+    private void Start()
+    {
+        // on game start, block character to walk left
+        if (GetComponentInParent<MapManager>().mapNumber <= 1)
+            RoadBlockEnable();
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        if (other.tag == "Player" && other.transform.position.x - transform.position.x > 0)
+        {
+            RoadBlockEnable();
+        }
+    }
+
+    public void RoadBlockEnable()
+    {
+        GetComponent<NavMeshObstacle>().enabled = true;
+    }
+}

--- a/Assets/Game/Scripts/MapGeneration/MapTriggers/RoadBlockActivate.cs.meta
+++ b/Assets/Game/Scripts/MapGeneration/MapTriggers/RoadBlockActivate.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d5aaa88317d313247ab5cc4a92de2735
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Imported/JMO Assets/Cartoon FX Remaster/CFXR Assets/Scripts.meta
+++ b/Assets/Imported/JMO Assets/Cartoon FX Remaster/CFXR Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 90cebaa0afdacee48a8b5ea661f8a1a7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Health.cs > health regen on Update() to smooth out regen
GameManager.cs > Removed maximum spawn count
RoadBlock.prefab, ProcedureGen.scene, MapManager.cs, NextMapCollider.cs > Enabled roadblock generation. On game start, road block to left will be enabled. In subsequent roadblocks, they're default disabled, but will be enabled On Collision Exit to the right